### PR TITLE
Allow setting CodeClimate default branch with envvars.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,8 @@ if ENV['CI']
 end
 ```
 
+If your default branch is something other than `master`, set `DEFAULT_BRANCH` in the environment to its name prior to running.
+
 After tests have finished:
 
 ```Bash

--- a/lib/codeclimate_batch.rb
+++ b/lib/codeclimate_batch.rb
@@ -23,13 +23,13 @@ module CodeclimateBatch
       report
     end
 
+    private
+
     # Return the default branch. Most of the time it's master, but can be overridden
     # by setting DEFAULT_BRANCH in the environment.
     def default_branch
       ENV['DEFAULT_BRANCH'] || 'master'
     end
-
-    private
 
     # Check if we are running on Travis CI.
     def travis?

--- a/lib/codeclimate_batch.rb
+++ b/lib/codeclimate_batch.rb
@@ -2,9 +2,11 @@ require 'json'
 
 module CodeclimateBatch
   class << self
-    # code climate only accepts reports from master but records coverage on all PRs -> wasted time
+    # Start TestReporter with appropriate settings.
+    # Note that Code Climate only accepts reports from the default branch (usually master, but can be changed)
+    # but records coverage on all PRs -> wasted time
     def start
-      return if ENV['TRAVIS'] && (ENV['TRAVIS_BRANCH'] != 'master' || ENV['TRAVIS_PULL_REQUEST'].to_i != 0)
+      return if travis? && (outside_default_branch? || pull_request?)
       ENV['CODECLIMATE_TO_FILE'] = '1' # write results to file since we need to combine them before sending
       gem 'codeclimate-test-reporter', '>= 0.4.8' # get CODECLIMATE_TO_FILE support and avoid deprecations
       require 'codeclimate-test-reporter'
@@ -21,7 +23,28 @@ module CodeclimateBatch
       report
     end
 
+    # Return the default branch. Most of the time it's master, but can be overridden
+    # by setting DEFAULT_BRANCH in the environment.
+    def default_branch
+      ENV['DEFAULT_BRANCH'] || 'master'
+    end
+
     private
+
+    # Check if we are running on Travis CI.
+    def travis?
+      ENV['TRAVIS']
+    end
+
+    # Check if our Travis build is running on the default branch.
+    def outside_default_branch?
+      default_branch != ENV['TRAVIS_BRANCH']
+    end
+
+    # Check if running a pull request.
+    def pull_request?
+      ENV['TRAVIS_PULL_REQUEST'].to_i != 0
+    end
 
     def load(file)
       JSON.load(File.read(file))

--- a/spec/codeclimate_batch_spec.rb
+++ b/spec/codeclimate_batch_spec.rb
@@ -84,6 +84,22 @@ describe CodeclimateBatch do
       end
     end
 
+    it "starts on different branch if set as default branch" do
+      default.merge! "TRAVIS_BRANCH" => "moooo", "DEFAULT_BRANCH" => "moooo"
+      with_env(default) do
+        CodeClimate::TestReporter.should_receive(:start)
+        CodeclimateBatch.start
+      end
+    end
+
+    it "does not starts on different branch if it doesn't match default branch" do
+      default.merge! "TRAVIS_BRANCH" => "moooo", "DEFAULT_BRANCH" => "monster"
+      with_env(default) do
+        CodeClimate::TestReporter.should_not_receive(:start)
+        CodeclimateBatch.start
+      end
+    end
+
     it "does not start on non-PR" do
       default["TRAVIS_PULL_REQUEST"] = "123"
       with_env(default) do


### PR DESCRIPTION
This is usually `master`, but doesn't have to be, depending on how a project is ran. This allows setting it to something else via the environment.
